### PR TITLE
Fix hero header slider feature and gubs

### DIFF
--- a/src/js/features/heroHeaderSlider.js
+++ b/src/js/features/heroHeaderSlider.js
@@ -5,10 +5,10 @@ import 'swiper/swiper-bundle.css';
 export default {
   //初期設定
   init: function() {
-    this.parentElem = document.getElementById('heroHeader');
-    if ( !this.parentElem ) return;
+    this.element = document.querySelector('#heroHeader .swiper-container');
+    if ( !this.element ) return;
 
-    this.swiper = new Swiper( this.parentElem.querySelector('.swiper-container'), {
+    this.swiper = new Swiper( this.element, {
       autoplay: {
         delay: 8000,
         disableOnInteraction: false,
@@ -54,7 +54,7 @@ export default {
 
   //スライダーの自動再生を開始
   play: function() {
-    if ( !this.parentElem ) return;
+    if ( !this.element ) return;
     this.swiper.autoplay.start();
     this.swiper.slides[0].style.animation = 'zoom-out 10s cubic-bezier(0.5, 1, 0.89, 1) both';
   },

--- a/src/js/features/heroHeaderSlider.js
+++ b/src/js/features/heroHeaderSlider.js
@@ -50,6 +50,12 @@ export default {
       simulateTouch : false,
       speed: 2000,
     } );
+
+    //スライダーが1つ以下の場合、ページネーションを非表示
+    if ( this.swiper.slides.length <= 1 ) {
+      this.swiper.pagination.destroy();
+      this.element.querySelector('.swiper-pagination').style.display = 'none';
+    }
   },
 
   //スライダーの自動再生を開始

--- a/template_parts/hero-header.php
+++ b/template_parts/hero-header.php
@@ -4,20 +4,29 @@
 
     <div class="swiper-container">
       <div class="swiper-wrapper">
-        <?php
-          $header_images = get_uploaded_header_images();
-          if ( get_theme_mod( 'header_image', '' ) === 'random-uploaded-image' ) shuffle( $header_images ); ?>
+        <?php $header_images = get_uploaded_header_images(); ?>
 
-        <?php foreach ( $header_images as $image ) : ?>
+        <?php if ( $header_images ) : ?>
+          <?php if ( get_theme_mod( 'header_image', '' ) === 'random-uploaded-image' ) shuffle( $header_images );
+          foreach ( $header_images as $image ) : ?>
+            <div class="swiper-slide">
+              <img
+                src="<?php echo esc_url( $image['url'] ); ?>"
+                alt="<?php echo esc_attr( $image['alt_text'] ); ?>"
+                width="<?php echo esc_attr( $image['width'] ); ?>"
+                height="<?php echo esc_attr( $image['height'] ); ?>"
+                data-object-fit="cover">
+            </div>
+          <?php endforeach; ?>
+
+        <?php else : ?>
           <div class="swiper-slide">
-            <img
-              src="<?php echo esc_url( $image['url'] ); ?>"
-              alt="<?php echo esc_attr( $image['alt_text'] ); ?>"
-              width="<?php echo esc_attr( $image['width'] ); ?>"
-              height="<?php echo esc_attr( $image['height'] ); ?>"
-              data-object-fit="cover">
+            <?php if ( get_header_image() ) : ?>
+              <img src="<?php header_image(); ?>" data-object-fit="cover">
+            <?php endif; ?>
           </div>
-        <?php endforeach; ?>
+        <?php endif; ?>
+
       </div><!--.swiper-wrapper-->
 
       <div class="swiper-pagination"></div>


### PR DESCRIPTION
ヒーローヘッダースライダー機能とバグを修正。

### 主な修正

-  WordPressでカスタムヘッダー画像が選択されていない場合、ヒーローヘッダースライダ
ーが機能しないバグを修正。

- スライダーの数が1つ以下の場合は、スライダーのページネーションを非表示。