### PR TITLE
Create 'works' and 'blogs' post type menus, archive pages and taxonomy pages respectively

### DIFF
--- a/archive-blogs.php
+++ b/archive-blogs.php
@@ -9,4 +9,19 @@
     <?php get_template_part('template_parts/post-list'); ?>
   </section>
 
+  <section>
+    <h2 class="main__heading-2">ブログカテゴリー</h2>
+    <div class="wrapper">
+      <ul class="category-list">
+        <?php wp_list_categories( [
+          'show_option_all' => '全て',
+          'orderby' => 'count',
+          'hierarchival' => 0,
+          'title_li' => '',
+          'taxonomy' => 'blogs-category',
+        ] ); ?>
+      </ul>
+    </div><!--.wrapper-->
+  </section>
+
 <?php get_footer(); ?>

--- a/archive-blogs.php
+++ b/archive-blogs.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+
+  <h1 class="main__heading-1" data-subtitle="- blogs -">ブログ</h1>
+
+  <section>
+    <div class="wrapper">
+      <h2 class="main__heading-2">ブログ一覧</h2>
+    </div><!--.wrapper-->
+    <?php get_template_part('template_parts/post-list'); ?>
+  </section>
+
+<?php get_footer(); ?>

--- a/archive-works.php
+++ b/archive-works.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+
+  <h1 class="main__heading-1" data-subtitle="- works -">作品</h1>
+
+  <section>
+    <div class="wrapper">
+      <h2 class="main__heading-2">作品一覧</h2>
+    </div><!--.wrapper-->
+    <?php get_template_part('template_parts/post-list'); ?>
+  </section>
+
+<?php get_footer(); ?>

--- a/archive-works.php
+++ b/archive-works.php
@@ -9,4 +9,19 @@
     <?php get_template_part('template_parts/post-list'); ?>
   </section>
 
+  <section>
+    <h2 class="main__heading-2">作品カテゴリー</h2>
+    <div class="wrapper">
+      <ul class="category-list">
+        <?php wp_list_categories( [
+          'show_option_all' => '全て',
+          'orderby' => 'count',
+          'hierarchival' => 0,
+          'title_li' => '',
+          'taxonomy' => 'works-category',
+        ] ); ?>
+      </ul>
+    </div><!--.wrapper-->
+  </section>
+
 <?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,17 @@ function create_taxonomies() {
     'hierarchical' => true,
     'show_in_rest' => true,
   ] );
+
+  //ブログカテゴリー
+  register_taxonomy( 'blogs-category', 'blogs', [
+    'labels' => [
+      'name' => 'ブログカテゴリー',
+      'all_items' => 'ブログカテゴリー一覧',
+    ],
+    'public' => true,
+    'hierarchical' => true,
+    'show_in_rest' => true,
+  ] );
 }
 
 //カスタム投稿タイプを作成

--- a/functions.php
+++ b/functions.php
@@ -41,4 +41,22 @@ function create_post_types() {
     'has_archive' => true,
     'show_in_rest' => true,
   ] );
+
+  //ブログ
+  register_post_type( 'blogs', [
+    'labels' => [
+      'name' => 'ブログ',
+      'all_items' => 'ブログ一覧',
+    ],
+    'public' => true,
+    'menu_position' => 5,
+    'menu_icon' => 'dashicons-edit-large',
+    'hierarchical' => true,
+    'supports' => [
+      'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks',
+      'custom-fields', 'comments', 'revisions', 'page-attributes', 'post-formats',
+    ],
+    'has_archive' => true,
+    'show_in_rest' => true,
+  ] );
 }

--- a/functions.php
+++ b/functions.php
@@ -4,4 +4,26 @@ add_action( 'wp_enqueue_scripts', 'museum_child_enqueue_scripts', 20 );
 function museum_child_enqueue_scripts() {
   wp_enqueue_style( 'child-style', get_stylesheet_directory_uri() . '/dist/css/style.css' );
   wp_enqueue_script( 'child-script', get_stylesheet_directory_uri() . '/dist/js/script.js', [], false, true );
-}  
+}
+
+//カスタム投稿タイプを作成
+add_action( 'init', 'create_post_types' );
+function create_post_types() {
+  //作品
+  register_post_type( 'works', [
+    'labels' => [
+      'name' => '作品',
+      'all_items' => '作品一覧',
+    ],
+    'public' => true,
+    'menu_position' => 5,
+    'menu_icon' => 'dashicons-format-image',
+    'hierarchical' => true,
+    'supports' => [
+      'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks',
+      'custom-fields', 'comments', 'revisions', 'page-attributes', 'post-formats',
+    ],
+    'has_archive' => true,
+    'show_in_rest' => true,
+  ] );
+}

--- a/functions.php
+++ b/functions.php
@@ -71,3 +71,91 @@ function create_post_types() {
     'show_in_rest' => true,
   ] );
 }
+
+//投稿リストの投稿アイテムを出力
+//※引数「$post_id」を指定しない場合、現在の投稿を取得。
+function custom_the_post_list_item( $post_id = null, $h_tag = 'h2' ) {
+  //投稿オブジェクトを取得
+  $post_obj = get_post( $post_id );
+  ?>
+
+  <article <?php post_class('post-item'); ?>>
+          
+    <a class="post-item__link" href="<?php the_permalink( $post_obj ); ?>">
+    
+      <?php if ( has_post_thumbnail( $post_obj->ID ) ) : ?>
+        <figure class="post-item__featured-media">
+          <?php echo get_the_post_thumbnail( $post_obj->ID, 'post-thumbnail', [ 'data-object-fit' => 'cover' ] ); ?>
+        </figure><!--post-item__featured-media-->
+      <?php endif; ?>
+
+      <div class="post-item__content">
+
+        <?php $post_title = esc_html( get_the_title( $post_obj ) );
+        if ( $post_title !== '' ) : ?>
+          <div class="post-item__content-header">
+            <<?=$h_tag?> class="post-item__content-title">
+              <?php echo $post_title; ?>
+            </<?=$h_tag?>>
+          </div><!--post-item__content-header-->
+        <?php endif; ?>
+        
+        <div class="post-item__content-footer">
+          <?php
+          $taxonomy = get_object_taxonomies( $post_obj, 'names' )[0];
+          $terms = get_the_terms( $post_obj->ID, $taxonomy );
+          if ( $terms ) : ?>
+            <div class="post-item__content-taxonomy">
+              <span class="post-item__content-taxonomy-icon">
+                <svg class="post-item__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
+                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                </svg>
+              </span>
+
+              <ul class="post-item__content-taxonomy-list">
+                <?php foreach ( $terms as $term ) : ?>
+                  <li class="post-item__content-taxonomy-list-item"><?php echo esc_html( $term->name ); ?></li>
+                <?php endforeach; ?>
+              </ul>
+            </div><!--.post-item__content-taxonomy-->
+          <?php endif; ?>
+        </div><!--post-item_content-footer-->
+      
+      </div><!--.post-item__content-->
+
+    </a>
+
+  </article><!--.post-item-->
+
+  <?php
+}
+
+//'load_count'URLパラメータを元に、前のページの投稿リストの投稿アイテムを出力
+function custom_the_prev_post_list_items( $h_tag = 'h2' ) {
+  global $wp_query;
+
+  if ( !isset( $_GET['load_count'] ) ) return;
+
+  $load_count = (int) wp_unslash( $_GET['load_count'] );
+  if ( $load_count <= 0 ) return;
+
+  $current_page = (int) get_query_var('paged');
+  if ( $current_page <= 0 ) $current_page = 1;
+
+  $load_page = $current_page - $load_count;
+  if ( $load_page <= 0 ) return;
+
+  $args = $wp_query->query_vars;
+  $args['paged'] = $load_page;
+  $args['posts_per_page'] = $load_count * (int) get_option('posts_per_page');
+
+  $query = new WP_Query( $args );
+
+  if ( $query->have_posts() ) {
+    while ( $query->have_posts() ) {
+      $query->the_post();
+      custom_the_post_list_item( $query->post->ID, $h_tag );
+    }
+    wp_reset_postdata();
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -6,6 +6,21 @@ function museum_child_enqueue_scripts() {
   wp_enqueue_script( 'child-script', get_stylesheet_directory_uri() . '/dist/js/script.js', [], false, true );
 }
 
+//カスタムタクソノミーを作成
+add_action( 'init', 'create_taxonomies' );
+function create_taxonomies() {
+  //作品カテゴリー
+  register_taxonomy( 'works-category', 'works', [
+    'labels' => [
+      'name' => '作品カテゴリー',
+      'all_items' => '作品カテゴリー一覧',
+    ],
+    'public' => true,
+    'hierarchical' => true,
+    'show_in_rest' => true,
+  ] );
+}
+
 //カスタム投稿タイプを作成
 add_action( 'init', 'create_post_types' );
 function create_post_types() {

--- a/singular.php
+++ b/singular.php
@@ -1,0 +1,106 @@
+<?php if ( is_attachment() ) wp_redirect( $post->guid ); ?>
+
+<?php get_header(); ?>
+
+  <?php if ( have_posts() ) : ?>
+    <?php while ( have_posts() ) : the_post(); ?>
+
+      <div class="wrapper -no-side-space -sp">
+
+        <article <?php post_class('post-single'); ?>>
+
+          <?php if ( has_post_thumbnail() ) : ?>
+            <figure class="post-single__featured-media">
+              <?php the_post_thumbnail( 'post-thumbnail', [ 'data-object-fit' => 'cover' ] ); ?>
+            </figure>
+          <?php endif; ?>
+
+          <div class="wrapper -no-side-space -pc -tc">
+            <div class="post-single__body">
+
+              <header class="post-single__header">
+
+                <?php if ( is_single() ) : ?>
+                  <div class="post-single__date">
+                    <span class="post-single__date-icon">
+                      <svg class="post-single__date-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <polyline points="12 6 12 12 16 14"></polyline>
+                      </svg>
+                    </span>
+
+                    <time class="post-single__date-value"><?php echo esc_html( get_the_time( get_option('date_format') ) ); ?></time>
+                  </div><!--.post-single__date-->
+                <?php endif; ?>
+
+                <?php the_title( '<h1 class="post-single__title">', '</h1>' ); ?>
+              </header>
+
+              <div class="post-single__content">
+                <?php the_content( 'READ MORE', true ); ?>
+                    
+                <?php wp_link_pages([
+                  'before' => '<div class="pagination">',
+                  'after' => '</div>',
+                ]); ?>
+              </div><!--.post-single__content-->
+
+              <?php if ( is_single() ) : ?>
+                <footer class="post-single__footer">
+                  <?php
+                  $post_type = get_post_type();
+                  if ( $post_type === 'works' ) $taxonomy = 'works-category';
+                  else if ( $post_type === 'blogs' ) $taxonomy = 'blogs-category';
+                  $terms = get_the_terms( $post->ID, $taxonomy );
+                  
+                  if ( $terms ) : ?>
+                    <div class="post-single__taxonomy">
+                      <span class="post-single__taxonomy-icon">
+                        <svg class="post-single__taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
+                          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                        </svg>
+                      </span>
+
+                      <ul class="post-single__taxonomy-list">
+                        <?php foreach ( $terms as $term ) : ?>
+                          <li class="post-single__taxonomy-list-item">
+                            <a class="post-single__taxonomy-list-item-link" href="<?php echo esc_url( get_term_link($term) ); ?>">
+                              <?php echo esc_html( $term->name ); ?>
+                            </a>
+                          </li>
+                        <?php endforeach; ?>
+                      </ul>
+                    </div><!--.post-single__taxonomy-->
+                  <?php endif; ?>
+
+                </footer>
+              <?php endif; ?>
+
+            </div><!--.post-single__body-->
+          </div><!--.wrapper-->
+
+        </article>
+
+      </div><!--.wrapper-->
+
+    <?php endwhile; ?>
+  <?php else : ?>
+
+    <p class="main__error-text">No posts</p>
+
+  <?php endif; ?>
+
+  <?php if ( is_single() ) : ?>
+    <div class="wrapper">
+      <?php get_template_part('template_parts/posts-navigation'); ?>
+    </div><!--.wrapper-->
+  <?php endif; ?>
+  
+  <?php if ( comments_open() && !post_password_required() ) : ?>
+    <div class="wrapper">
+      <h2 class="main__heading-2">コメントフォーム</h2>
+      <?php comments_template(); ?>
+    </div><!--.wrapper-->
+  <?php endif; ?>
+  
+<?php get_footer(); ?>

--- a/src/sass/blocks/_category-list.scss
+++ b/src/sass/blocks/_category-list.scss
@@ -1,0 +1,33 @@
+.category-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  
+  li {
+    border: 0.5px solid $black;
+    border-radius: 3px;
+    margin: 4px;
+
+    a {
+      color: inherit;
+      display: block;
+      padding: 2px 10px;
+      transition: background 0.2s linear, color 0.2s linear;
+
+      &:hover, &:focus {
+        background: $black;
+        color: white;
+        outline: none;
+      }
+    }
+
+    &.current-cat a {
+      background: $black;
+      color: white;
+      pointer-events: none;
+    }
+  }
+}

--- a/taxonomy-blogs-category.php
+++ b/taxonomy-blogs-category.php
@@ -1,0 +1,14 @@
+<?php get_header(); ?>
+
+  <h1 class="main__heading-1" data-subtitle="- works -">ブログ</h1>
+
+  <section>
+    <div class="wrapper">
+      <h2 class="main__heading-2">
+        <?php echo esc_html( get_queried_object()->name ); ?>
+      </h2>
+    </div><!--.wrapper-->
+    <?php get_template_part('template_parts/post-list'); ?>
+  </section>
+
+<?php get_footer(); ?>

--- a/taxonomy-blogs-category.php
+++ b/taxonomy-blogs-category.php
@@ -11,4 +11,19 @@
     <?php get_template_part('template_parts/post-list'); ?>
   </section>
 
+  <section>
+    <h2 class="main__heading-2">ブログカテゴリー</h2>
+    <div class="wrapper">
+      <ul class="category-list">
+        <?php wp_list_categories( [
+          'show_option_all' => '全て',
+          'orderby' => 'count',
+          'hierarchival' => 0,
+          'title_li' => '',
+          'taxonomy' => 'blogs-category',
+        ] ); ?>
+      </ul>
+    </div><!--.wrapper-->
+  </section>
+
 <?php get_footer(); ?>

--- a/taxonomy-works-category.php
+++ b/taxonomy-works-category.php
@@ -10,5 +10,20 @@
     </div><!--.wrapper-->
     <?php get_template_part('template_parts/post-list'); ?>
   </section>
+  
+  <section>
+    <h2 class="main__heading-2">作品カテゴリー</h2>
+    <div class="wrapper">
+      <ul class="category-list">
+        <?php wp_list_categories( [
+          'show_option_all' => '全て',
+          'orderby' => 'count',
+          'hierarchival' => 0,
+          'title_li' => '',
+          'taxonomy' => 'works-category',
+        ] ); ?>
+      </ul>
+    </div><!--.wrapper-->
+  </section>
 
 <?php get_footer(); ?>

--- a/taxonomy-works-category.php
+++ b/taxonomy-works-category.php
@@ -1,0 +1,14 @@
+<?php get_header(); ?>
+
+  <h1 class="main__heading-1" data-subtitle="- works -">作品</h1>
+
+  <section>
+    <div class="wrapper">
+      <h2 class="main__heading-2">
+        <?php echo esc_html( get_queried_object()->name ); ?>
+      </h2>
+    </div><!--.wrapper-->
+    <?php get_template_part('template_parts/post-list'); ?>
+  </section>
+
+<?php get_footer(); ?>

--- a/template_parts/post-list.php
+++ b/template_parts/post-list.php
@@ -1,0 +1,53 @@
+<?php if ( have_posts() ) : ?>
+  <article id="postList" class="post-list">
+
+    <div class="post-list__posts">
+
+      <div class="post-list__posts-sizer"></div>
+
+      <?php custom_the_prev_post_list_items( 'h3' ); ?>
+
+      <?php while ( have_posts() ) : the_post(); ?>
+        
+        <?php custom_the_post_list_item( $post->ID, 'h3' ); ?>
+
+      <?php endwhile; ?>
+
+    </div><!--.post-list__posts-->
+
+    <button class="post-list__show-more-button" type="button">SEE MORE</button>
+
+    <div class="post-list__page-load-status">
+      <div class="infinite-scroll-request">
+        <div class="loader-ellips">
+          <span class="loader-ellips__dot"></span>
+          <span class="loader-ellips__dot"></span>
+          <span class="loader-ellips__dot"></span>
+          <span class="loader-ellips__dot"></span>
+        </div>
+      </div>
+      <p class="infinite-scroll-last">End of content</p>
+      <p class="infinite-scroll-error">No more pages to load</p>
+    </div>
+
+    <?php if ( $wp_query->max_num_pages > 1 ) : ?>
+      <div class="post-list__navigation">
+
+        <span class="post-list__navigation-prev-page-link">
+          <?php previous_posts_link( '&lt; PREV PAGE' ); ?>
+        </span>
+
+        <span class="post-list__navigation-next-page-link">
+          <?php next_posts_link( 'NEXT PAGE &gt;' ); ?>
+        </span>
+
+      </div><!--.post-list__navigation-->
+    <?php endif; ?>
+
+  </article><!--.post-list-->
+
+<?php else : ?>
+
+  <p class="main__error-text">No posts</p>
+
+<?php endif; ?>


### PR DESCRIPTION
WordPressの'作品'と'ブログ'の投稿タイプメニュー、それぞれのアーカイブページ、タクソノミーページを作成。