### PR TITLE
Fix a bug that the horizontal scroll bar was displayed before the opening animation ended

### DIFF
--- a/src/sass/blocks/_hero-header.scss
+++ b/src/sass/blocks/_hero-header.scss
@@ -10,4 +10,8 @@
       z-index: 3;
     }
   }
+
+  &__heading {
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
オープニングアニメーション終了前に横スクロールバーが表示されるバグを修正。

詳細 #26